### PR TITLE
Update submodule commands to include "--recursive"

### DIFF
--- a/post-checkout
+++ b/post-checkout
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-git submodule update --init
+git submodule update --init --recursive

--- a/post-merge
+++ b/post-merge
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-git submodule update --init
+git submodule update --init --recursive

--- a/post-rewrite
+++ b/post-rewrite
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-git submodule update --init
+git submodule update --init --recursive

--- a/pre-commit
+++ b/pre-commit
@@ -22,7 +22,7 @@ if [ "${BRANCH_NAME}" = "master" ]; then
  	exit 1
 fi
 
-SUBMOD_DIRTY_CHECK=`git submodule foreach git describe --dirty | grep "dirty"`
+SUBMOD_DIRTY_CHECK=`git submodule foreach --recursive git describe --dirty | grep "dirty"`
 if [ ! "${SUBMOD_DIRTY_CHECK}" = "" ]; then
 	echo ""
 	echo "*******************************************************************"


### PR DESCRIPTION
This PR modifies the git submodule commands to include the "--recursive" modifier to allow submodules to contain submodules. This is necessary for E3SM PR #3507.

[BFB]